### PR TITLE
Update to use oncall API

### DIFF
--- a/jobs/pagerduty_oncall.rb
+++ b/jobs/pagerduty_oncall.rb
@@ -1,5 +1,6 @@
 require 'faraday'
 require 'json'
+require 'pp'
 # make sure your secrets.json has an "escalation_policy":"blahblah" entry
 
 data_file = './lib/secrets.json'
@@ -7,32 +8,37 @@ parsed_data = JSON.parse( IO.read( data_file ))
 
 url = parsed_data['url']
 api_key = parsed_data['api_key']
-escalation_policy = parsed_data['escalation_policy']
 
-oncalls = {}
+# empty array of oncalls
+oncall = {}
+
+# for each ep....
+parsed_data['escalation_policies'].each do |key, value|
+  oncall[key] = value
+end
 
 SCHEDULER.every '5s' do
+  oncall.each do |key,value|
     conn = Faraday.new(:url => "#{url}") do |faraday|
       faraday.request :url_encoded
       faraday.adapter Faraday.default_adapter
       faraday.headers['Content-type'] = 'application/json'
       faraday.headers['Authorization'] = "Token token=#{api_key}"
-      faraday.params['since'] = Time.now.utc.iso8601()
-      faraday.params['until'] = (Time.now.utc + 60).iso8601()
    end
 
-  response = conn.get "/api/v1/escalation_policies/#{escalation_policy}/on_call"
+  response = conn.get "/api/v1/escalation_policies/#{value}/on_call"
+  pp(response)
   if response.status == 200
     oncall_result = JSON.parse(response.body)
     #Note: this is currently broken for group alerting. Need to make it just look for the first entry where level:1, then where level:2
-    primary = oncall_result['escalation_policy']['on_call'][0]['user']['name']
-    secondary = oncall_result['escalation_policy']['on_call'][1]['user']['name']
+    user_name = oncall_result['escalation_policy']['on_call'][0]['user']['name']
   else
     user_name = 'John Doe'
   end
 
-  send_event("primary-name", { text: primary})
-  send_event("backup-name", { text: secondary})
+  send_event("#{key}-name", { text: user_name})
+  end
+
+
 
 end
-


### PR DESCRIPTION
PagerDuty has a special-purpose API to return who is currently on-call for an escalation policy:

https://pdt-circular.pagerduty.com/api/v1/escalation_policies/on_call

It's not documented, but you can also stick an EP parameter in there, IE 

https://pdt-circular.pagerduty.com/api/v1/escalation_policies/123456/on_call

There's some logic I need to fix as far as primary vs. secondary goes. Right now, it just returns the first two user entries in the 'user' blob, when what it should actually do is return the first user with level=1, and then the first user with level=2. Or, to get fancier, it should actually return all users on a given level.

```
"on_call":[
{
"level":1,
"start":"2014-05-11T07:00:00Z",
"end":"2014-05-12T07:00:00Z",
"user":{
"id":"P7QCNF1",
"name":"Amy Chantasirivisal",
"email":"amy@pagerduty.com",
"time_zone":"Pacific Time (US & Canada)",
"color":"turquoise"
}
},
{
"level":1,
"start":null,
"end":null,
"user":{
"id":"PYUUVV3",
"name":"Test 1",
"email":"test@example.com",
"time_zone":"Pacific Time (US & Canada)",
"color":"orange-red"
}
},
{
"level":1,
"start":"2014-03-06T08:00:00Z",
"end":"2015-05-08T23:13:24Z",
"user":{
"id":"PPFTW3L",
"name":"Jobs",
"email":"dave+jobs@pagerduty.com",
"time_zone":"Pacific Time (US & Canada)",
"color":"teal"
}
},
{
"level":2,
"start":null,
"end":null,
"user":{
"id":"PYUUVV3",
"name":"Test 1",
"email":"test@example.com",
"time_zone":"Pacific Time (US & Canada)",
"color":"orange-red"
}
},
{
"level":2,
"start":"2014-03-02T02:22:00Z",
"end":"2015-05-08T23:13:25Z",
"user":{
"id":"PVYIT4B",
"name":"Manisha Koirala (India)",
"email":"india@example.com",
"time_zone":"Pacific Time (US & Canada)",
"color":"dark-slate-blue"
}
}
```
